### PR TITLE
Updates client to deal with server payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,20 +126,16 @@ class Renderer {
       // { [string]: { error: Error?, html: string, job: Job } }
       // eslint-disable-next-line arrow-body-style
       return axios.post(this.url, item.jobsHash, this.config).then((res) => {
-        return {
-          error: null,
-          results: reduce(res.data, {}, (obj, key) => {
-            const body = res.data[key];
+        const results = res.data.results;
 
-            obj[key] = { // eslint-disable-line no-param-reassign
-              error: body.error,
-              html: body.error ? renderHTML(key, data[key]) : body.html,
-              job: item.jobsHash[key],
-            };
+        Object.keys(results).forEach((key) => {
+          const body = results[key];
 
-            return obj;
-          }, {}),
-        };
+          body.job = item.jobsHash[key];
+          body.html = body.error ? renderHTML(key, data[key]) : body.html;
+        });
+
+        return res.data;
       });
     })
     // if there is an error retrieving the result set or converting it then lets just fallback

--- a/test/server.js
+++ b/test/server.js
@@ -6,13 +6,16 @@ const app = express();
 app.use(bodyParser.json());
 
 app.post('/', (req, res) => {
-  res.send(Object.keys(req.body).reduce((obj, key) => {
-    obj[key] = {
-      error: req.query.error ? new Error(req.query.error) : null,
-      html: `<div>${JSON.stringify(req.body[key].data)}</div>`,
-    };
-    return obj;
-  }, {}));
+  res.send({
+    error: null,
+    results: Object.keys(req.body).reduce((obj, key) => {
+      obj[key] = {
+        error: req.query.error ? new Error(req.query.error) : null,
+        html: `<div>${JSON.stringify(req.body[key].data)}</div>`,
+      };
+      return obj;
+    }, {}),
+  });
 });
 
 module.exports = app.listen(28001);


### PR DESCRIPTION
This should fix #3 

Turns out the client was never updated to reflect the changes in Hypernova's new format where the batch results are in a `results` key rather than at the top-level.

This PR fixes that and updates our internal mock server to mimic Hypernova's response.

@ljharb 