### PR TITLE
Matches example port number to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const devModePlugin = require('../plugins/devModePlugin');
 const app = express();
 
 const renderer = new Renderer({
-  url: 'http://localhost:3553/batch',
+  url: 'http://localhost:3030/batch',
   plugins: [
     devModePlugin,
   ],

--- a/examples/exampleServer.js
+++ b/examples/exampleServer.js
@@ -5,7 +5,7 @@ const devModePlugin = require('../plugins/devModePlugin');
 const app = express();
 
 const renderer = new Renderer({
-  url: 'http://localhost:3553/batch',
+  url: 'http://localhost:3030/batch',
   plugins: [
     devModePlugin,
   ],


### PR DESCRIPTION
Fixes #2 

We're syncing the port number here with the one found in the [main Hypernova repo example](https://github.com/airbnb/hypernova#node).

@ljharb 