### PR TITLE
Allows top level errors to continue through

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function fallback(error, jobs) {
     results: reduce(jobs, {}, (obj, key) => {
       // eslint-disable-next-line no-param-reassign
       obj[key] = {
-        error,
+        error: null,
         html: renderHTML(key, jobs[key].data),
         job: jobs[key],
       };
@@ -147,7 +147,7 @@ class Renderer {
       const results = res.results;
 
       try {
-        if (res.error) throw res.error;
+        if (res.error) this.pluginReduce('onError', plugin => plugin(res.error, results));
 
         values(results).forEach((job) => {
           if (job.error) {


### PR DESCRIPTION
Previously top-level errors, which not only come from the server but
were also added as the fallback approach, would throw, be caught, and
call onError and return an empty markup for client side rendering. This
was ok but `afterResponse` wasn't running which would potentially impact
plugins that would use this to check for errors that happened in
`willRequest`, or `getViewData`.

Now when a top-level error is encountered we continue the flow,
`onError` is called for the error and then we proceed to iterate over
each job and call `afterResponse`.

If an error is encountered during that process then we terminate and
fallback to empty markup.

@ljharb 